### PR TITLE
fix getTranslationsForLocale

### DIFF
--- a/sprd/model/Design.js
+++ b/sprd/model/Design.js
@@ -141,7 +141,7 @@ define(['sprd/data/SprdModel', 'sprd/model/PrintType', 'sprd/entity/Size', 'sprd
                 translation;
 
             if (translations) {
-                for (var i = 0, num = translations.length; i > num; i++) {
+                for (var i = 0, num = translations.length; i < num; i++) {
                     translation = translations[i];
 
                     if (translation.get('locale.id') === locale) {

--- a/sprd/model/Design.js
+++ b/sprd/model/Design.js
@@ -144,7 +144,7 @@ define(['sprd/data/SprdModel', 'sprd/model/PrintType', 'sprd/entity/Size', 'sprd
                 for (var i = 0, num = translations.length; i < num; i++) {
                     translation = translations[i];
 
-                    if (translation.get('locale.id') === locale) {
+                    if (translation.get('locale.id') === locale.get('id')) {
                         return translation;
                     }
                 }


### PR DESCRIPTION
Since the for loop is wrong and the id of the locale doesn't get compared, the previous translations never get returned. This causes multiple translations on the design object, which is not cool.
